### PR TITLE
v0.8.2 - Amend for libsaxbospiral v0.22.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ endif()
 # add custom dependencies directory
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 # libsaxbospiral
-find_package(Saxbospiral 0.21 EXACT REQUIRED)
+find_package(Saxbospiral 0.22 EXACT REQUIRED)
 include_directories(${SAXBOSPIRAL_INCLUDE_DIR})
 # Argtable
 find_package(Argtable REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # begin basic metadata
 cmake_minimum_required(VERSION 3.0)
 
-project(sxbp VERSION 0.8.1 LANGUAGES C)
+project(sxbp VERSION 0.8.2 LANGUAGES C)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(

--- a/cmake/Modules/FindSaxbospiral.cmake
+++ b/cmake/Modules/FindSaxbospiral.cmake
@@ -7,6 +7,8 @@
 #  SAXBOSPIRAL_INCLUDE_DIRS - the SAXBOSPIRAL include directory
 #  SAXBOSPIRAL_LIBRARIES - Link these to use SAXBOSPIRAL
 
+# TODO: Get it to find the actual correct version of libsaxbospiral
+
 find_path(
     SAXBOSPIRAL_INCLUDE_DIR
     NAMES "saxbospiral/saxbospiral.h"
@@ -22,8 +24,6 @@ find_library(
 set(SAXBOSPIRAL_INCLUDE_DIRS ${SAXBOSPIRAL_INCLUDE_DIR})
 set(SAXBOSPIRAL_LIBRARIES ${SAXBOSPIRAL_LIBRARY})
 
-# handle the QUIETLY and REQUIRED arguments and set JSONCPP_FOUND to TRUE
-# if all listed variables are TRUE, hide their existence from configuration view
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
     saxbospiral DEFAULT_MSG SAXBOSPIRAL_INCLUDE_DIR SAXBOSPIRAL_LIBRARY

--- a/sxbp.c
+++ b/sxbp.c
@@ -28,13 +28,13 @@
 #include <string.h>
 
 #include <argtable2.h>
-#include <saxbospiral-0.21/saxbospiral.h>
-#include <saxbospiral-0.21/initialise.h>
-#include <saxbospiral-0.21/solve.h>
-#include <saxbospiral-0.21/serialise.h>
-#include <saxbospiral-0.21/render.h>
-#include <saxbospiral-0.21/render_backends/backend_pbm.h>
-#include <saxbospiral-0.21/render_backends/backend_png.h>
+#include <saxbospiral-0.22/saxbospiral.h>
+#include <saxbospiral-0.22/initialise.h>
+#include <saxbospiral-0.22/solve.h>
+#include <saxbospiral-0.22/serialise.h>
+#include <saxbospiral-0.22/render.h>
+#include <saxbospiral-0.22/render_backends/backend_pbm.h>
+#include <saxbospiral-0.22/render_backends/backend_png.h>
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
This is necessary because the header files of v0.21.x are incompatible with the binary ABI of v0.22.0